### PR TITLE
Improve Worker request forwarding

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -10,6 +10,11 @@ async function handleRequest(request) {
     // Extract the base path to determine the API route
     const basePath = url.pathname.split('/')[1];
 
+    // Validate basePath to avoid empty values
+    if (!basePath) {
+        return new Response('Invalid request', { status: 400 });
+    }
+
     // Fetch the target host from Workers KV
     const targetHost = await kvNamespace.get(`/${basePath}`);
 
@@ -19,15 +24,12 @@ async function handleRequest(request) {
 
     // Update the URL to point to the target host
     url.host = targetHost;
-    url.pathname = url.pathname.replace(`/${basePath}`, ''); // Remove basePath
+    // Normalize pathname by removing only the leading basePath segment
+    url.pathname = url.pathname.replace(new RegExp(`^/${basePath}`), '') || '/';
 
     // Forward the request to the target API
-    const proxiedRequest = new Request(url, {
-        method: request.method,
-        headers: request.headers,
-        body: request.body,
-        redirect: 'follow'
-    });
+    // Clone the original request while updating the URL
+    const proxiedRequest = new Request(url.toString(), request);
 
     return fetch(proxiedRequest);
 }


### PR DESCRIPTION
## Summary
- validate incoming requests to ensure a base path is present
- normalize the forwarded request pathname
- clone the original request correctly when forwarding

## Testing
- `node -c src/worker.js`


------
https://chatgpt.com/codex/tasks/task_e_687b5517ac408320b9dd96bb41a89588